### PR TITLE
fix citation format

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,6 @@
 abstract: "Imageomics-focused guide to collaborative work, including GitHub and Hugging Face workflows."
 authors:
-- family-names:
-  given-names: "Campolongo"
+- family-names: "Campolongo"
   given-names: "Elizabeth G."
   orcid: "https://orcid.org/0000-0003-0846-2413"
 - family-names: "Thompson"
@@ -32,6 +31,7 @@ keywords:
   - "best practices"
   - "cheat-sheet"
   - "command line cheat-sheet"
+  - "collaborative science"
   - projects
   - "collaborative workflows"
   - standards


### PR DESCRIPTION
Discovered a small bug in the `CITATION.cff` format that removed my last name. Also added one more keyword.