### PR TITLE
Update source for workflow diagram

### DIFF
--- a/docs/wiki-guide/The-GitHub-Workflow.md
+++ b/docs/wiki-guide/The-GitHub-Workflow.md
@@ -128,5 +128,5 @@ git pull
 
 And for a slightly abbreviated visual summary, the same workflow looks like this:
 
-![GitHub workflow diagram](https://www.getdbt.com/ui/img/guides/analytics-engineering/git-workflow-1.png){ loading=lazy }
-(image credit: [dbt Labs](https://www.getdbt.com/analytics-engineering/transformation/git-workflow/))
+![GitHub workflow diagram explaining origin vs local with interactions of clone, pull, and push between](https://jiayiwu.me/images/git_icon-781e4cc0.png){ loading=lazy }
+(image credit: [Jiayi Wu Cox Blog](https://jiayiwu.me/blog/2021/07/30/version-control-with-git.html), noted source: Learning note from “Version Control with Git” by Atlassian offered by Steve Byrnes on [Coursera](https://www.coursera.org/learn/version-control-with-git).)


### PR DESCRIPTION
Original diagram reference ([dbt labs](https://www.getdbt.com/analytics-engineering/transformation/git-workflow/)) is no longer available. The earliest instance in [Google image search](https://www.google.com/search?sca_esv=bbbacaefae974866&lns_surface=44&q=&vsrid=COqKkd36tOKPSxACGAEiJGE1MDNhZTBkLTJmYzYtNDkxZi1iNWFhLTdhMzliMmU5MzBiYTjypqzFtNWNAw&vsint=CAIqDAoCCAcSAggKGAEgATojChYNAAAAPxUAAAA_HQAAgD8lAACAPzABEOgHGLIEJQAAgD8&lns_mode=un&source=lns.web.quimby&vsdim=1000,562&gsessionid=MieOZt4LzbbH9h14ysK6gIGsSNBfQTkXW48XlAyDLe-UF5TKdzFePA&lsessionid=kCO_cOxRz5snlZaxjd1yFkaLpxV9g3_g6cHgca-At8Vr7032h4KvbQ&udm=48&fbs=AIIjpHyDuDaSWI128HHkGNYTlSjb1_oTF4ZmPtdzykbpzfBSpb5sLBh_s3SW7YmAyVMS_U2h5ElB&sa=X&ved=2ahUKEwj_28PFtNWNAxVEHkQIHd91B1EQs6gLegQIDhAB&biw=1678&bih=818&dpr=1) is [this blog](https://jiayiwu.me/blog/2021/07/30/version-control-with-git.html) which cites a [Coursera course](https://www.coursera.org/learn/version-control-with-git) created in 2018 (no idea when the figure was added); the first record from original ref (dbt) on [Internet Wayback Machine](https://web.archive.org/web/20210815000000*/https://www.getdbt.com/ui/img/guides/analytics-engineering/git-workflow-1.png) is a month after the blog post.