### PR TITLE
Rename for template guide

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,10 +20,10 @@ date-released: "2024-11-DD"
 identifiers:
   - description: "The GitHub release URL of tag v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/Imageomics-guide/releases/tag/v1.0.0"
+    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/releases/tag/v1.0.0"
   - description: "The GitHub URL of the commit tagged with <tag-name>." # update post release
     type: url
-    value: "https://github.com/Imageomics/Imageomics-guide/tree/<commit-hash>" # update post release
+    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/<commit-hash>" # update post release
 keywords:
   - imageomics
   - metadata
@@ -37,6 +37,6 @@ keywords:
   - standards
 license: CC0-1.0
 message: "If you find these docs helpful in your research, please cite them as below."
-repository-code: "https://github.com/Imageomics/Imageomics-guide"
+repository-code: "https://github.com/Imageomics/Collaborative-distributed-science-guide"
 title: "Imageomics Guide"
 version: "1.0.0"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Imageomics Guide
+# Collaborative Distributed Science Guide
 
-Welcome to the Imageomics Guide!
+Welcome to the Collaborative Distributed Science Guide!
 
 Just joining or starting a new project? 
-Checkout the [Imageomics Guide](https://imageomics.github.io/Imageomics-guide/) for guidance on conventions and best practices.
+Checkout the [Collaborative Distributed Science Guide](https://imageomics.github.io/Collaborative-distributed-science-guide/) for guidance on conventions and best practices.
 
 ## About the Guide
 
-This guide started as an Institute-internal wiki, focused on providing guidance and best practices for collaborative and interdisciplinary (computer science + biology) work. Recognizing that the topics and suggestions are broadly applicable to anyone working in similar or adjacent fields, we moved the vast majority to this [guide](https://imageomics.github.io/Imageomics-guide/). To increase accessibility for those less familiar with GitHub, we generated the [web site](https://imageomics.github.io/Imageomics-guide/) from our Markdown documents (which used to be wiki pages) with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
+This guide started as an Institute-internal wiki, focused on providing guidance and best practices for collaborative and interdisciplinary (computer science + biology) work. Recognizing that the topics and suggestions are broadly applicable to anyone working in similar or adjacent fields, we moved the vast majority to this [guide](https://imageomics.github.io/Collaborative-distributed-science-guide/). To increase accessibility for those less familiar with GitHub, we generated the web site from our Markdown documents (which used to be wiki pages) with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
 
-Please feel free to open an [issue](https://github.com/Imageomics/Imageomics-guide/issues) with any questions regarding the content fo this guide or if you would like to contribute to the [Glossary](https://imageomics.github.io/Imageomics-guide/wiki-guide/Glossary-for-Imageomics/) or [Helpful Tools page](https://imageomics.github.io/Imageomics-guide/wiki-guide/Helpful-Tools-for-your-Workflow/).
+Please feel free to open an [issue](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues) with any questions regarding the content of this guide.
 
 ### Testing
 To test this site locally, first clone this repository, then create an environment with `requirements.txt`
@@ -20,4 +20,4 @@ and run `mkdocs serve`:
 ```
 mkdocs serve
 ```
-Then the site will run at http://127.0.0.1:8000/Imageomics-guide/.
+Then the site will run at http://127.0.0.1:8000/Collaborative-distributed-science-guide/.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Welcome to the Imageomics Institute Guide!
+# Welcome to the Collaborative Distributed Science Guide!
 
 This website hosts guides to Imageomics workflows, documentation, and general best-practices for collaborative science. We aim to provide a helpful resource for a broad base of scientists working in the field of [_imageomics_](wiki-guide/Glossary-for-Imageomics.md/#imageomics) and beyond.
 
@@ -68,4 +68,4 @@ We have two versions of the logo, a [fish](logos/Imageomics_logo_fish.png) and a
 <br>
 <br>
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"

--- a/docs/wiki-guide/Code-Checklist.md
+++ b/docs/wiki-guide/Code-Checklist.md
@@ -104,4 +104,4 @@ The [Repo Guide](GitHub-Repo-Guide.md/) provides general guidance on repository 
 - [ ] **Packaging**: Provide installation instructions (e.g., `setup.py`, `hatch`, `poetry`, `uv` for Python).
 - [ ] **Deployment Guide**: Document deployment procedures
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"

--- a/docs/wiki-guide/DOI-Generation.md
+++ b/docs/wiki-guide/DOI-Generation.md
@@ -71,4 +71,4 @@ When creating a new record on Zenodo, please ensure that other members of your p
 
 [Dryad](https://datadryad.org/stash/about) is another research data repository, similar to Zenodo, through which one can archive digital objects (such as, but not limited to, data) supporting scholarly publications, and obtain a DOI. It has a review process when depositing data and requires dedication to the public domain (CC0) of all digital objects uploaded. Imageomics through OSU is a member organization of Dryad, reducing or eliminating data deposit charge(s). To determine whether Dryad is a suitable archive for Institute data products supporting your publication, please consider the [Data Archive Options Comparative Overview](../pdfs/Data_Archive-Publication-Options-Comparative-Overview.pdf) for more information, and consult with the Institute's Senior Data Scientist.[^1]
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"

--- a/docs/wiki-guide/Data-Checklist.md
+++ b/docs/wiki-guide/Data-Checklist.md
@@ -107,4 +107,4 @@ See discussion and references in the [template](HF_DatasetCard_Template_mkdocs.m
 
 - [ ] **Contact Information**: [OPTIONAL] We recommend people use HF discussions, but you may indicate a person to contact.
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"

--- a/docs/wiki-guide/FAIR-Guide.md
+++ b/docs/wiki-guide/FAIR-Guide.md
@@ -26,7 +26,7 @@ The last topic in this section discusses different methods of [DOI Generation](D
     - The [FARR Research Coordination Network](https://www.farr-rcn.org/) has a number of interesting resources and events.
     - The [Research Data Aliance for Interdisciplinary Research](https://www.rd-alliance.org/disciplines/rda-for-interdisciplinary-research/) also provides links to resources and events particularly focused on considerations in interdisciplinary research.
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"
 
 [^1]: While "Reproducible" is not part of the original FAIR principles as defined by the [Go-FAIR Initiative](https://www.go-fair.org/fair-principles/), we include it here to emphasize the importance of computational reproducibility alongside data stewardship. This extension reflects emerging practice in data-intensive science, where code, models, and workflows must be reusable and verifiable to support robust scientific claims. It is not part of the formal FAIR acronym, but aligns with broader community goals for open and transparent research.
 [^2]: Full reproducibility is difficult to achieve; this [presentation](https://drive.google.com/file/d/1BFqZ00zMuyVHaD9A8PvzRDEg7aV0kp3W/view?usp=drive_link) by Odd Erik Gundersen provides a discussion of the varying degrees of reproducibilityand useful references when considering the level of reproducibility achieved by a given project.  

--- a/docs/wiki-guide/HF_DatasetCard_Template_mkdocs.md
+++ b/docs/wiki-guide/HF_DatasetCard_Template_mkdocs.md
@@ -5,7 +5,7 @@ Below are the Dataset Card templates for Imageomics and ABC. You can download or
 <details>
 <summary>Imageomics</summary>
 </br>
-<b><a href="https://github.com/Imageomics/Imageomics-guide/blob/main/docs/wiki-guide/HF_DatasetCard_Template_Imageomics.md" target="_blank">Download template from GitHub</a></b>
+<b><a href="https://github.com/Imageomics/Collaborative-distributed-science-guide/blob/main/docs/wiki-guide/HF_DatasetCard_Template_Imageomics.md" target="_blank">Download template from GitHub</a></b>
 
 {{ include_file_as_code("docs/wiki-guide/HF_DatasetCard_Template_Imageomics.md") }}
 
@@ -14,7 +14,7 @@ Below are the Dataset Card templates for Imageomics and ABC. You can download or
 <details>
 <summary>ABC</summary>
 </br>
-<b><a href="https://github.com/Imageomics/Imageomics-guide/blob/main/docs/wiki-guide/HF_DatasetCard_Template_ABC.md" target="_blank">Download template from GitHub</a></b>
+<b><a href="https://github.com/Imageomics/Collaborative-distributed-science-guide/blob/main/docs/wiki-guide/HF_DatasetCard_Template_ABC.md" target="_blank">Download template from GitHub</a></b>
 
 {{ include_file_as_code("docs/wiki-guide/HF_DatasetCard_Template_ABC.md") }}
 

--- a/docs/wiki-guide/HF_ModelCard_Template_mkdocs.md
+++ b/docs/wiki-guide/HF_ModelCard_Template_mkdocs.md
@@ -5,7 +5,7 @@ Below are the Model Card templates for Imageomics and ABC. You can download or c
 <details>
 <summary>Imageomics</summary>
 </br>
-<b><a href="https://github.com/Imageomics/Imageomics-guide/blob/main/docs/wiki-guide/HF_ModelCard_Template_Imageomics.md" target="_blank">Download template from GitHub</a></b>
+<b><a href="https://github.com/Imageomics/Collaborative-distributed-science-guide/blob/main/docs/wiki-guide/HF_ModelCard_Template_Imageomics.md" target="_blank">Download template from GitHub</a></b>
 
 
 {{ include_file_as_code("docs/wiki-guide/HF_ModelCard_Template_Imageomics.md") }}
@@ -15,7 +15,7 @@ Below are the Model Card templates for Imageomics and ABC. You can download or c
 <details>
 <summary>ABC</summary>
 </br>
-<b><a href="https://github.com/Imageomics/Imageomics-guide/blob/main/docs/wiki-guide/HF_ModelCard_Template_ABC.md" target="_blank">Download template from GitHub</a></b>
+<b><a href="https://github.com/Imageomics/Collaborative-distributed-science-guide/blob/main/docs/wiki-guide/HF_ModelCard_Template_ABC.md" target="_blank">Download template from GitHub</a></b>
 
 {{ include_file_as_code("docs/wiki-guide/HF_ModelCard_Template_ABC.md") }}
 

--- a/docs/wiki-guide/Helpful-Tools-for-your-Workflow.md
+++ b/docs/wiki-guide/Helpful-Tools-for-your-Workflow.md
@@ -1,6 +1,6 @@
 # Helpful Tools for your Workflow
 
-This page is dedicated to tools that can facilitate or improve project workflows. If there's something you use regularly that you think should be on this list, please [suggest it](https://github.com/Imageomics/Imageomics-guide/issues)!
+This page is dedicated to tools that can facilitate or improve project workflows. If there's something you use regularly that you think should be on this list, please [suggest it](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)!
 
 ## Jupytext
 

--- a/docs/wiki-guide/Metadata-Checklist.md
+++ b/docs/wiki-guide/Metadata-Checklist.md
@@ -41,4 +41,4 @@ To improve both the _**Findability**_ and _**Reusability**_ of your data (ensuri
 
     Use the eye icon at the top of this page to access the source and copy the markdown for the checklist above into an issue on your GitHub [Repo](GitHub-Repo-Guide.md) or [Project](Guide-to-GitHub-Projects.md) so you can check the boxes as you add each.
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"

--- a/docs/wiki-guide/Model-Checklist.md
+++ b/docs/wiki-guide/Model-Checklist.md
@@ -127,4 +127,4 @@ See discussion and references in the [template](HF_ModelCard_Template_mkdocs.md/
 - [ ] **Model Card Authors**: List contributors to the model card.
 - [ ] **Model Card Contact**: [OPTIONAL] We recommend people use HF discussions, but you may indicate a person to contact.
 
-!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Imageomics-guide/issues)"
+!!! question "[Questions, Comments, or Concerns?](https://github.com/Imageomics/Collaborative-distributed-science-guide/issues)"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,10 +1,10 @@
-site_name: "Imageomics Guide"
-site_description: "A guide to collaborative work for Imageomics, including GitHub and Hugging Face workflows."
+site_name: "Collaborative Distributed Science Guide"
+site_description: "A guide to collaborative work (originally for Imageomics), including GitHub and Hugging Face workflows."
 site_author: "Imageomics Institute"
-site_url: "https://Imageomics.github.io/Imageomics-guide/"
+site_url: "https://Imageomics.github.io/Collaborative-distributed-science-guide/"
 edit_uri: view/main/docs
 
-repo_url: https://github.com/Imageomics/Imageomics-guide
+repo_url: https://github.com/Imageomics/Collaborative-distributed-science-guide
 edit_uri: blob/main/docs/
 
 theme:


### PR DESCRIPTION
Closes #43: 'Imageomics-guide' to 'Collaborative-distributed-science-guide' in URLs and descriptions. Step one in #38.