### PR TITLE
Set Imageomics Color-Scheme

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -25,3 +25,72 @@ based on this suggestion: https://github.com/squidfunk/mkdocs-material/discussio
   padding-top: .175rem;
   padding-bottom: .175rem;
 }
+
+/* 
+Define Imageomics colors for theme (light and dark)
+Primary Colors:
+- Imageomics Green: #92991c
+- Imageomics Blue: #5d8095
+- Dark Teal: #0097b2
+- White: #FFFFFF
+Accent Colors:
+- Light Green: #9bcb5e
+- Red: #bb0000
+- NSF Gold: #caae54
+- NSF Blue: #61a5d6
+Adjust admonitions and links to match (where otherwise clashed)
+*/
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        #0097b2;
+  --md-accent-fg-color:         #92991c;
+  --md-footer-bg-color:         #92991c;
+}
+
+/* Set admonition (Note) colors to match the primary blue */
+/* border color */
+.md-typeset .admonition.note, .md-typeset details.note {
+    border-color: var(--md-primary-fg-color);
+    box-shadow: #0097b21a;
+}
+
+/* icon color */
+.md-typeset .admonition.note > .admonition-title::before {
+    background-color: #0097b2;
+}
+
+/* shaded part (title/heading) */
+.md-typeset .note>.admonition-title,.md-typeset .note>summary {
+    background-color: #0097b21a;
+}
+
+/* Set admonition (question) colors to match the accent green */
+/* border color */
+.md-typeset .admonition.question, .md-typeset details.question {
+    border-color: var(--md-accent-fg-color);
+    box-shadow: #9bcb5e1a;
+}
+
+/* icon color */
+.md-typeset .admonition.question > .admonition-title::before {
+    background-color: var(--md-accent-fg-color);
+}
+
+/* shaded part (title/heading) */
+.md-typeset .question>.admonition-title,.md-typeset .question>summary {
+    background-color: #9bcb5e1a;
+}
+
+.md-typeset a {
+  color: #0097b2;
+}
+
+.md-nav .md-nav__link--active {
+  color: #0097b2;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #5d8095;
+  --md-accent-fg-color:         #92991c;
+  --md-footer-bg-color--dark:   #93991ca4;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -26,7 +26,7 @@ based on this suggestion: https://github.com/squidfunk/mkdocs-material/discussio
   padding-bottom: .175rem;
 }
 
-/* 
+/*
 Define Imageomics colors for theme (light and dark)
 Primary Colors:
 - Imageomics Green: #92991c
@@ -41,16 +41,16 @@ Accent Colors:
 Adjust admonitions and links to match (where otherwise clashed)
 */
 
+/* Light mode colors: Imageomics Blue and Light Green */
 [data-md-color-scheme="default"] {
-  --md-primary-fg-color:        #0097b2;
-  --md-accent-fg-color:         #92991c;
-  --md-footer-bg-color:         #92991c;
+  --md-primary-fg-color:        #5d8095;
+  --md-accent-fg-color:         #9bcb5e;
 }
 
-/* Set admonition (Note) colors to match the primary blue */
+/* Set admonition (Note) colors to match Dark Teal used for URLs */
 /* border color */
 .md-typeset .admonition.note, .md-typeset details.note {
-    border-color: var(--md-primary-fg-color);
+    border-color: #0097b2;
     box-shadow: #0097b21a;
 }
 
@@ -64,7 +64,8 @@ Adjust admonitions and links to match (where otherwise clashed)
     background-color: #0097b21a;
 }
 
-/* Set admonition (question) colors to match the accent green */
+/* Set admonition (question) colors to match the accent green
+  Light Green for light mode, Imageomics Green for dark mode */
 /* border color */
 .md-typeset .admonition.question, .md-typeset details.question {
     border-color: var(--md-accent-fg-color);
@@ -81,16 +82,19 @@ Adjust admonitions and links to match (where otherwise clashed)
     background-color: #9bcb5e1a;
 }
 
+/* Set URL colors to Dark Teal for better contrast */
+/* Content URLs */
 .md-typeset a {
   color: #0097b2;
 }
 
+/* Navigation URL (side panel contents) */
 .md-nav .md-nav__link--active {
   color: #0097b2;
 }
 
+/* Dark mode colors: Imageomics Blue and Imageomics Green */
 [data-md-color-scheme="slate"] {
   --md-primary-fg-color:        #5d8095;
   --md-accent-fg-color:         #92991c;
-  --md-footer-bg-color--dark:   #93991ca4;
 }


### PR DESCRIPTION
Following offline discussion with Imageomics Data & Infrastructure Team, sets colors to Imageomics schemes while maintaining sufficient contrast.

Matches admonitions to URLs and hover colors (note and question, respectively) to avoid contrasting colors and ensure they stand out.

Light Mode (hover on PR Guide & Project Management):
<img width="1339" height="516" alt="Screenshot 2025-09-05 at 3 39 18 PM" src="https://github.com/user-attachments/assets/4370eea9-e6fe-49f5-a8da-8cc6def5d4fd" />
<img width="1304" height="621" alt="Screenshot 2025-09-05 at 3 41 09 PM" src="https://github.com/user-attachments/assets/a88c0334-1fa7-42cd-bb87-a53232110762" />

Dark Mode (hover on PR Guide & Project Management):
<img width="1259" height="503" alt="Screenshot 2025-09-05 at 3 39 55 PM" src="https://github.com/user-attachments/assets/7fdb48ad-cca2-4094-82db-22babd588e33" />
<img width="1351" height="641" alt="Screenshot 2025-09-05 at 3 40 46 PM" src="https://github.com/user-attachments/assets/dd3d80e7-d8e4-49b8-a7cc-41e8e758aa36" />

Resolves #62.